### PR TITLE
Move copy/import tooltip so the button stays visible

### DIFF
--- a/src/components/SvgIconViewer.vue
+++ b/src/components/SvgIconViewer.vue
@@ -25,7 +25,8 @@
           >
             <q-tooltip
               anchor="top middle"
-              self="top middle"
+              self="bottom middle"
+              :offset="[10,10]"
               class="primary my-tooltip"
             >
               Copy name "{{ name }}" to clipboard
@@ -41,7 +42,8 @@
           >
             <q-tooltip
               anchor="top middle"
-              self="top middle"
+              self="bottom middle"
+              :offset="[10,10]"
               class="primary my-tooltip"
             >
               Copy "import &#123; {{ name }} &#125; from '{{ store.iconSet.packageName }}/{{ store.iconSet.value }}'" to clipboard


### PR DESCRIPTION
When you hover the copy/import buttons the tooltip shows up above the buttons and I can never tell if I clicked in the right place.
Moving it a bit up, keeps the button visible